### PR TITLE
Update ED URL to drop "identity.html"

### DIFF
--- a/identity.js
+++ b/identity.js
@@ -28,7 +28,7 @@ var respecConfig = {
   // copyrightStart: "2005",
 
   // if there a publicly available Editor's Draft, this is the link
-  edDraftURI: "https://w3c.github.io/webrtc-identity/identity.html",
+  edDraftURI: "https://w3c.github.io/webrtc-identity/",
 
   // if this is a LCWD, uncomment and set the end of its review period
   // lcEnd: "2009-08-05",


### PR DESCRIPTION
https://w3c.github.io/webrtc-identity/identity.html and https://w3c.github.io/webrtc-identity/ are identical.

Having "identity.html" in the URL seems superfluous and some tools/docs use the latter URL as a result. See discussion in:
https://github.com/w3c/browser-specs/issues/284