### PR TITLE
Give Global an identifier list as required by Web IDL

### DIFF
--- a/identity.html
+++ b/identity.html
@@ -126,7 +126,7 @@
         <var>rtcIdentityProvider</var> in the global scope of the <a>realm</a>.
         This object is used by the IdP to interact with the user agent.</p>
         <div>
-          <pre class="idl">[Global, Exposed=RTCIdentityProviderGlobalScope]
+          <pre class="idl">[Global=(Worker,RTCIdentityProvider), Exposed=RTCIdentityProvider]
 interface RTCIdentityProviderGlobalScope : WorkerGlobalScope {
     readonly        attribute RTCIdentityProviderRegistrar rtcIdentityProvider;
 };</pre>
@@ -177,7 +177,7 @@ interface RTCIdentityProviderGlobalScope : WorkerGlobalScope {
       user agent cannot use the IdP proxy and MUST fail any future attempt to
       interact with the IdP.</p>
       <div>
-        <pre class="idl">[Exposed=RTCIdentityProviderGlobalScope]
+        <pre class="idl">[Exposed=RTCIdentityProvider]
 interface RTCIdentityProviderRegistrar {
     undefined register (RTCIdentityProvider idp);
 };


### PR DESCRIPTION
See https://webidl.spec.whatwg.org/#dfn-global-name

This follows the example of DedicatedWorkerGlobalScope:
https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-dedicatedworkerglobalscope-interface


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 3, 2022, 9:17 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Ffoolip%2Fwebrtc-identity%2F424c595f28269bd81924860ccb99d310353570f9%2Fidentity.html%3FisPreview%3Dtrue)

```
Navigation timeout of 29503 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-identity%2336.)._
</details>
